### PR TITLE
fix column index numbers for queries where ga was removed

### DIFF
--- a/style/marc/MARC21slim2XTFDC.xsl
+++ b/style/marc/MARC21slim2XTFDC.xsl
@@ -200,10 +200,10 @@ source: http://www.loc.gov/standards/marcxml/xslt/MARC21slim2SRWDC.xsl
 </facet-institution>
 
        <institution-url xtf:meta="true" xtf:tokenize="false">
-               <xsl:value-of select="$cdlpath_query/r/c[4]"/>
+               <xsl:value-of select="$cdlpath_query/r/c[3]"/>
        </institution-url>
        <aeon_url xtf:meta="true" xtf:tokenize="false">
-               <xsl:value-of select="$cdlpath_query/r/c[5]"/>
+               <xsl:value-of select="$cdlpath_query/r/c[4]"/>
        </aeon_url>
 
         <identifier q="call" xtf:meta="true">

--- a/style/textIndexer/common/preFilterCommon.xsl
+++ b/style/textIndexer/common/preFilterCommon.xsl
@@ -520,10 +520,10 @@
 		<xsl:value-of select="($parentRepodata)/parent/div[5]"/>
 	</institution-url>	
 	<aeon_url xtf:meta="true" xtf:tokenize="false">
-		<xsl:value-of select="($parentRepodata)/parent/div[7]"/>
+		<xsl:value-of select="($parentRepodata)/parent/div[6]"/>
 	</aeon_url>
 	<aeon_data_parameter xtf:meta="true" xtf:tokenize="false">
-		<xsl:value-of select="($parentRepodata)/parent/div[8]"/>
+		<xsl:value-of select="($parentRepodata)/parent/div[7]"/>
 	</aeon_data_parameter>
 	<xsl:choose> <!-- main choice is 2 listings or 1 listing -->
 		<xsl:when test="($grandparentARK)/g/a != ''"> <!-- there are 2 -->


### PR DESCRIPTION
When I removed the GA snippet from these queries I missed that some of the returned values were being accessed by index.  Fix them.